### PR TITLE
Path pruning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,10 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Flyfinder\\": ["tests/unit/"]
+      "Flyfinder\\": [
+        "tests/integration/",
+        "tests/unit/"
+      ]
     }
   },
   "require": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,12 +17,15 @@
     <rule ref="Generic.Files.LineLength.TooLong">
         <exclude-pattern>*/src/Finder.php</exclude-pattern>
         <exclude-pattern>*/src/Specification/SpecificationInterface.php</exclude-pattern>
+        <exclude-pattern>*/src/Specification/PrunableInterface.php</exclude-pattern>
+        <exclude-pattern>*/src/Specification/CompositeSpecification.php</exclude-pattern>
         <exclude-pattern>*/tests/unit/Specification/GlobTest.php</exclude-pattern>
     </rule>
 
 
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix">
         <exclude-pattern>*/src/Specification/SpecificationInterface.php</exclude-pattern>
+        <exclude-pattern>*/src/Specification/PrunableInterface.php</exclude-pattern>
     </rule>
 
     <rule ref="Generic.Formatting.SpaceAfterNot">

--- a/src/Finder.php
+++ b/src/Finder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Flyfinder;
 
+use Flyfinder\Specification\CompositeSpecification;
 use Flyfinder\Specification\SpecificationInterface;
 use Generator;
 use League\Flysystem\File;
@@ -88,13 +89,13 @@ class Finder implements PluginInterface
                 yield $location;
             }
 
-            if ($location['type'] !== 'dir') {
+            if ($location['type'] !== 'dir'
+                || !CompositeSpecification::thatCanBeSatisfiedBySomethingBelow($specification, $location)
+            ) {
                 continue;
             }
 
-            foreach ($this->yieldFilesInPath($specification, $location['path']) as $returnedLocation) {
-                yield $returnedLocation;
-            }
+            yield from $this->yieldFilesInPath($specification, $location['path']);
         }
     }
 }

--- a/src/Specification/AndSpecification.php
+++ b/src/Specification/AndSpecification.php
@@ -42,4 +42,18 @@ final class AndSpecification extends CompositeSpecification
     {
         return $this->one->isSatisfiedBy($value) && $this->other->isSatisfiedBy($value);
     }
+
+    /** {@inheritDoc} */
+    public function canBeSatisfiedBySomethingBelow(array $value) : bool
+    {
+        return self::thatCanBeSatisfiedBySomethingBelow($this->one, $value)
+            && self::thatCanBeSatisfiedBySomethingBelow($this->other, $value);
+    }
+
+    /** {@inheritDoc} */
+    public function willBeSatisfiedByEverythingBelow(array $value) : bool
+    {
+        return self::thatWillBeSatisfiedByEverythingBelow($this->one, $value)
+            && self::thatWillBeSatisfiedByEverythingBelow($this->other, $value);
+    }
 }

--- a/src/Specification/CompositeSpecification.php
+++ b/src/Specification/CompositeSpecification.php
@@ -19,7 +19,7 @@ namespace Flyfinder\Specification;
  *
  * @psalm-immutable
  */
-abstract class CompositeSpecification implements SpecificationInterface
+abstract class CompositeSpecification implements SpecificationInterface, PrunableInterface
 {
     /**
      * Returns a specification that satisfies the original specification
@@ -46,5 +46,48 @@ abstract class CompositeSpecification implements SpecificationInterface
     public function notSpecification() : NotSpecification
     {
         return new NotSpecification($this);
+    }
+
+    /** {@inheritDoc} */
+    public function canBeSatisfiedBySomethingBelow(array $value) : bool
+    {
+        return true;
+    }
+
+    /** {@inheritDoc} */
+    public function willBeSatisfiedByEverythingBelow(array $value) : bool
+    {
+        return false;
+    }
+
+    /**
+     * Provide default {@see canBeSatisfiedBySomethingBelow()} logic for specification classes
+     * that don't implement PrunableInterface
+     *
+     * @param mixed[] $value
+     *
+     * @psalm-param array{basename: string, path: string, stream: resource, dirname: string, type: string, extension: string} $value
+     * @psalm-mutation-free
+     */
+    public static function thatCanBeSatisfiedBySomethingBelow(SpecificationInterface $that, array $value) : bool
+    {
+        return $that instanceof PrunableInterface
+                ? $that->canBeSatisfiedBySomethingBelow($value)
+                : true;
+    }
+
+    /**
+     * Provide default {@see willBeSatisfiedByEverythingBelow()} logic for specification classes
+     * that don't implement PrunableInterface
+     *
+     * @param mixed[] $value
+     *
+     * @psalm-param array{basename: string, path: string, stream: resource, dirname: string, type: string, extension: string} $value
+     * @psalm-mutation-free
+     */
+    public static function thatWillBeSatisfiedByEverythingBelow(SpecificationInterface $that, array $value) : bool
+    {
+        return $that instanceof PrunableInterface
+            && $that->willBeSatisfiedByEverythingBelow($value);
     }
 }

--- a/src/Specification/InPath.php
+++ b/src/Specification/InPath.php
@@ -14,7 +14,12 @@ declare(strict_types=1);
 namespace Flyfinder\Specification;
 
 use Flyfinder\Path;
+use function array_slice;
+use function count;
+use function explode;
+use function implode;
 use function in_array;
+use function min;
 use function preg_match;
 use function str_replace;
 
@@ -84,5 +89,21 @@ class InPath extends CompositeSpecification
         }
 
         return false;
+    }
+
+    /** @inheritDoc */
+    public function canBeSatisfiedBySomethingBelow(array $value) : bool
+    {
+        $pathSegments       = explode('/', (string) $this->path);
+        $valueSegments      = explode('/', $value['path']);
+        $pathPrefixSegments = array_slice($pathSegments, 0, min(count($pathSegments), count($valueSegments)));
+        $spec               = new InPath(new Path(implode('/', $pathPrefixSegments)));
+        return $spec->isSatisfiedBy($value);
+    }
+
+    /** @inheritDoc */
+    public function willBeSatisfiedByEverythingBelow(array $value) : bool
+    {
+        return $this->isSatisfiedBy($value);
     }
 }

--- a/src/Specification/NotSpecification.php
+++ b/src/Specification/NotSpecification.php
@@ -38,4 +38,16 @@ final class NotSpecification extends CompositeSpecification
     {
         return !$this->wrapped->isSatisfiedBy($value);
     }
+
+    /** @inheritDoc */
+    public function canBeSatisfiedBySomethingBelow(array $value) : bool
+    {
+        return !self::thatWillBeSatisfiedByEverythingBelow($this->wrapped, $value);
+    }
+
+    /** @inheritDoc */
+    public function willBeSatisfiedByEverythingBelow(array $value) : bool
+    {
+        return !self::thatCanBeSatisfiedBySomethingBelow($this->wrapped, $value);
+    }
 }

--- a/src/Specification/OrSpecification.php
+++ b/src/Specification/OrSpecification.php
@@ -42,4 +42,18 @@ final class OrSpecification extends CompositeSpecification
     {
         return $this->one->isSatisfiedBy($value) || $this->other->isSatisfiedBy($value);
     }
+
+    /** @inheritDoc */
+    public function canBeSatisfiedBySomethingBelow(array $value) : bool
+    {
+        return self::thatCanBeSatisfiedBySomethingBelow($this->one, $value)
+            || self::thatCanBeSatisfiedBySomethingBelow($this->other, $value);
+    }
+
+    /** @inheritDoc */
+    public function willBeSatisfiedByEverythingBelow(array $value) : bool
+    {
+        return self::thatWillBeSatisfiedByEverythingBelow($this->one, $value)
+            || self::thatWillBeSatisfiedByEverythingBelow($this->other, $value);
+    }
 }

--- a/src/Specification/PrunableInterface.php
+++ b/src/Specification/PrunableInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flyfinder\Specification;
+
+/**
+ * Interface PrunableInterface
+ *
+ * @psalm-immutable
+ */
+interface PrunableInterface
+{
+    /**
+     * Checks if anything under the directory path in value can possibly satisfy the specification.
+     *
+     * @param mixed[] $value
+     *
+     * @psalm-param array{basename: string, path: string, stream: resource, dirname: string, type: string, extension: string} $value
+     */
+    public function canBeSatisfiedBySomethingBelow(array $value) : bool;
+
+    /**
+     * Returns true if it is known or can be deduced that everything under the directory path in value
+     * will certainly satisfy the specification.
+     *
+     * @param mixed[] $value
+     *
+     * @psalm-param array{basename: string, path: string, stream: resource, dirname: string, type: string, extension: string} $value
+     */
+    public function willBeSatisfiedByEverythingBelow(array $value) : bool;
+}

--- a/tests/unit/FinderTest.php
+++ b/tests/unit/FinderTest.php
@@ -13,10 +13,22 @@ declare(strict_types=1);
 
 namespace Flyfinder;
 
+use Flyfinder\Specification\Glob;
+use Flyfinder\Specification\HasExtension;
+use Flyfinder\Specification\InPath;
 use Flyfinder\Specification\IsHidden;
+use Generator;
 use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemInterface;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use function array_map;
+use function array_values;
+use function iterator_to_array;
+use function pathinfo;
+use function sort;
+use function substr;
+use function trim;
 
 /**
  * Test case for Finder
@@ -48,6 +60,111 @@ class FinderTest extends TestCase
     {
         $this->assertSame('find', $this->fixture->getMethod());
     }
+
+    public function testIfNotHiddenLetsSubpathsThrough() : void
+    {
+        $files = [ 'foo/bar/.hidden/baz/not-hidden.txt' ];
+        $this->fixture->setFilesystem($this->mockFileSystem($files));
+        $notHidden = (new IsHidden())->notSpecification();
+        $this->assertEquals(
+            $files,
+            $this->generatorToFileList($this->fixture->handle($notHidden))
+        );
+    }
+
+    public function testIfDoubleNotHiddenLetsSubpathsThrough() : void
+    {
+        $files = [ '.foo/.bar/not-hidden/.baz/.hidden.txt' ];
+        $this->fixture->setFilesystem($this->mockFileSystem($files));
+        $notHidden = (new IsHidden())->notSpecification()->notSpecification();
+        $this->assertEquals(
+            $files,
+            $this->generatorToFileList($this->fixture->handle($notHidden))
+        );
+    }
+
+    public function testIfNeitherHiddenNorExtLetsSubpathsThrough() : void
+    {
+        $files = [ 'foo/bar/.hidden/baz.ext/neither-hidden-nor.ext.zzz' ];
+        $this->fixture->setFilesystem($this->mockFileSystem($files));
+
+        $neitherHiddenNorExt =
+            (new IsHidden())->notSpecification()
+                ->andSpecification((new HasExtension(['ext']))->notSpecification());
+        $this->assertEquals(
+            $files,
+            $this->generatorToFileList($this->fixture->handle($neitherHiddenNorExt))
+        );
+
+        $neitherHiddenNorExtDeMorgan = (new IsHidden())->orSpecification(new HasExtension(['ext']))->notSpecification();
+        $this->assertEquals(
+            $files,
+            $this->generatorToFileList($this->fixture->handle($neitherHiddenNorExtDeMorgan))
+        );
+    }
+
+    public function testIfNegatedOrCullsExactMatches() : void
+    {
+        $files = [
+            'foo/bar/baz/whatever.txt',
+            'foo/gen/pics/bottle.jpg',
+            'foo/lou/time.txt',
+        ];
+        $this->fixture->setFilesystem($this->mockFileSystem($files, ['foo/bar', 'foo/gen']));
+
+        $negatedOr =
+            (new InPath(new Path('foo/gen')))
+                ->orSpecification(new InPath(new Path('foo/bar')))
+                ->notSpecification();
+
+        $this->assertEquals(
+            ['foo/lou/time.txt'],
+            $this->generatorToFileList($this->fixture->handle($negatedOr))
+        );
+
+        $negatedOrDeMorgan =
+            (new InPath(new Path('foo/gen')))->notSpecification()
+            ->andSpecification((new InPath(new Path('foo/bar')))->notSpecification());
+
+        $this->assertEquals(
+            ['foo/lou/time.txt'],
+            $this->generatorToFileList($this->fixture->handle($negatedOrDeMorgan))
+        );
+    }
+
+    public function testIfNegatedAndCullsExactMatches() : void
+    {
+        $files    = [
+            'foo/bar/baz/whatever.txt',
+            'foo/gen/pics/bottle.jpg',
+            'foo/lou/time.txt',
+        ];
+        $expected = [
+            'foo/gen/pics/bottle.jpg',
+            'foo/lou/time.txt',
+        ];
+        $this->fixture->setFilesystem($this->mockFileSystem($files, ['foo/bar']));
+
+        $negatedAnd =
+            (new InPath(new Path('foo/*')))
+                ->andSpecification(new InPath(new Path('*/bar')))
+                ->notSpecification();
+
+        $this->assertEquals(
+            $expected,
+            $this->generatorToFileList($this->fixture->handle($negatedAnd))
+        );
+
+        $negatedAndDeMorgan =
+            (new InPath(new Path('foo/*')))->notSpecification()
+                ->orSpecification((new InPath(new Path('*/bar')))->notSpecification());
+
+        $this->assertEquals(
+            $expected,
+            $this->generatorToFileList($this->fixture->handle($negatedAndDeMorgan))
+        );
+    }
+
 
     /**
      * @covers ::handle
@@ -97,6 +214,10 @@ class FinderTest extends TestCase
             ->with($listContents1[0])
             ->andReturn(true);
 
+        $isHidden->shouldReceive('canBeSatisfiedBySomethingBelow')
+            ->with($listContents1[0])
+            ->andReturn(true);
+
         $isHidden->shouldReceive('isSatisfiedBy')
             ->with($listContents1[1])
             ->andReturn(false);
@@ -126,5 +247,213 @@ class FinderTest extends TestCase
         ];
 
         $this->assertSame($expected, $result);
+    }
+
+    public function testSubtreePruningOptimization() : void
+    {
+        $filesystem = $this->mockFileSystem(
+            [
+                'foo/bar/baz/file.txt',
+                'foo/bar/baz/file2.txt',
+                'foo/bar/baz/excluded/excluded.txt',
+                'foo/bar/baz/excluded/culled/culled.txt',
+                'foo/bar/baz/excluded/important/reincluded.txt',
+                'foo/bar/file3.txt',
+                'foo/lou/someSubdir/file4.txt',
+                'foo/irrelevant1/',
+                'irrelevant2/irrelevant3/irrelevantFile.txt',
+            ],
+            [
+                'foo/irrelevant1',
+                'irrelevant2',
+                'foo/bar/baz/excluded/culled',
+            ]
+        );
+
+        $inFooBar = new InPath(new Path('foo/bar'));
+        $inFooLou = new InPath(new Path('foo/lou'));
+        $inExcl   = new InPath(new Path('foo/bar/baz/excl*'));
+        $inReincl = new InPath(new Path('foo/bar/baz/*/important'));
+        $spec     =
+            $inFooBar
+                ->orSpecification($inFooLou)
+                ->andSpecification($inExcl->notSpecification())
+                ->orSpecification($inReincl);
+
+        $finder = $this->fixture;
+        $finder->setFilesystem($filesystem);
+        $generator = $finder->handle($spec);
+
+        $expected = [
+            'foo/bar/baz/file.txt',
+            'foo/bar/baz/file2.txt',
+            'foo/bar/file3.txt',
+            'foo/bar/baz/excluded/important/reincluded.txt',
+            'foo/lou/someSubdir/file4.txt',
+        ];
+        sort($expected);
+
+        $this->assertEquals($expected, $this->generatorToFileList($generator));
+    }
+
+    public function testGlobSubtreePruning() : void
+    {
+        $filesystem  = $this->mockFileSystem(
+            [
+                'foo/bar/baz/file.txt',
+                'foo/bar/baz/file2.txt',
+                'foo/bar/baz/excluded/excluded.txt',
+                'foo/bar/baz/excluded/culled/culled.txt',
+                'foo/bar/baz/excluded/important/reincluded.txt',
+                'foo/bar/file3.txt',
+                'foo/lou/someSubdir/file4.txt',
+                'foo/irrelevant1/',
+                'irrelevant2/irrelevant3/irrelevantFile.txt',
+            ],
+            [
+                'foo/irrelevant1',
+                'irrelevant2',
+                'foo/bar/baz/excluded/culled',
+            ]
+        );
+        $txtInFooBar = new Glob('/foo/bar/**/*.txt');
+        $inFooLou    = new Glob('/foo/lou/**/*');
+        $inExcl      = new Glob('/foo/bar/baz/excl*/**/*');
+        $inReincl    = new Glob('/foo/bar/baz/*/important/**/*');
+        $spec        = $txtInFooBar
+            ->orSpecification($inFooLou)
+            ->andSpecification($inExcl->notSpecification())
+            ->orSpecification($inReincl);
+
+        $finder = $this->fixture;
+        $finder->setFilesystem($filesystem);
+        $generator = $finder->handle($spec);
+        $expected  = [
+            'foo/bar/baz/file.txt',
+            'foo/bar/baz/file2.txt',
+            'foo/bar/file3.txt',
+            'foo/bar/baz/excluded/important/reincluded.txt',
+            'foo/lou/someSubdir/file4.txt',
+        ];
+        sort($expected);
+
+        $this->assertEquals($expected, $this->generatorToFileList($generator));
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function generatorToFileList(Generator $generator) : array
+    {
+        $actual = array_values(array_map(static function ($v) {
+            return $v['path'];
+        }, iterator_to_array($generator)));
+        sort($actual);
+        return $actual;
+    }
+
+    /**
+     * @param string[] $pathList
+     *
+     * @return mixed[]
+     */
+    protected function mockFileTree(array $pathList) : array
+    {
+        $result = [
+            '.' => [
+                'type' => 'dir',
+                'path' => '',
+                'dirname' => '.',
+                'basename' => '.',
+                'filename' => '.',
+                'contents' => [],
+            ],
+        ];
+        foreach ($pathList as $path) {
+            $isFile = substr($path, -1) !== '/';
+            $child  = null;
+            while (true) {
+                $info = pathinfo($path);
+                if ($isFile) {
+                    $isFile        = false;
+                    $result[$path] = [
+                        'type' => 'file',
+                        'path' => $path,
+                        'dirname' => $info['dirname'],
+                        'basename' => $info['basename'],
+                        'filename' => $info['filename'],
+                        'extension' => $info['extension'],
+                    ];
+                } else {
+                    $existed = true;
+                    if (!isset($result[$path])) {
+                        $existed       = false;
+                        $result[$path] = [
+                            'type' => 'dir',
+                            'path' => $path,
+                            'basename' => $info['basename'],
+                            'filename' => $info['filename'],
+                            'contents' => [],
+                        ];
+                    }
+                    if ($child!==null) {
+                        $result[$path]['contents'][] = $child;
+                    }
+                    if ($existed) {
+                        break;
+                    }
+                }
+                $child = $info['basename'];
+                $path  = $info['dirname'];
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * @param mixed[] $fileTreeMock
+     *
+     * @return mixed[]
+     */
+    protected function mockListContents(array $fileTreeMock, string $path) : array
+    {
+        $path = trim($path, '/');
+        if (substr($path . '  ', 0, 2)==='./') {
+            $path = substr($path, 2);
+        }
+        if ($path==='') {
+            $path = '.';
+        }
+
+        if (!isset($fileTreeMock[$path]) || $fileTreeMock[$path]['type'] === 'file') {
+            return [];
+        }
+        $result = [];
+        foreach ($fileTreeMock[$path]['contents'] as $basename) {
+            $childPath = ($path==='.' ? '' : $path . '/') . $basename;
+            if (!isset($fileTreeMock[$childPath])) {
+                continue;
+            }
+
+            $result[$basename] = $fileTreeMock[$childPath];
+        }
+        return $result;
+    }
+
+    /**
+     * @param string[] $paths
+     * @param string[] $pathsThatShouldNotBeListed
+     */
+    protected function mockFileSystem(array $paths, array $pathsThatShouldNotBeListed = []) : FilesystemInterface
+    {
+        $fsData     = $this->mockFileTree($paths);
+        $filesystem = m::mock(Filesystem::class);
+        $filesystem->shouldReceive('listContents')
+            ->zeroOrMoreTimes()
+            ->andReturnUsing(function (string $path) use ($fsData, $pathsThatShouldNotBeListed) : array {
+                $this->assertNotContains($path, $pathsThatShouldNotBeListed);
+                return array_values($this->mockListContents($fsData, $path));
+            });
+        return $filesystem;
     }
 }


### PR DESCRIPTION
Introduce an optimized variant of the traversal algorithm (fixes issue #14). If enabled by
```php
$plugin->setAlgorithm(Finder::ALGORITHM_OPTIMIZED);
```
the plugin will perform a preliminary check of each directory against the specification using the new API:
```php
if (!$specification->canBeSatisfiedByAnythingBelow($value)) {
    continue;
}
```
Integration tests and `FinderTest` are updated to test both algorithms.