### PR TITLE
Upgrade tools to fix installation

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install phive
         run: make install-phive
       - name: Install PHAR dependencies
-        run: tools/phive.phar --no-progress install --copy --trust-gpg-keys 4AA394086372C20A,D2CCAC42F6295E7D,8A03EA3B385DBAA1,CF1A108D0E7AE720 --force-accept-unsigned
+        run: tools/phive.phar --no-progress install --copy --trust-gpg-keys CF1A108D0E7AE720,D2CCAC42F6295E7D,4AA394086372C20A,12CE0F1D262429A5 --force-accept-unsigned
 
   phpunit-with-coverage:
     runs-on: ubuntu-latest
@@ -69,7 +69,6 @@ jobs:
         with:
           php-version: 7.2
           coverage: xdebug
-          pecl: false
       - name: Run PHPUnit
         run: php tools/phpunit
 
@@ -122,12 +121,13 @@ jobs:
           restore-keys: |
             all-tools-${{ github.sha }}-
             all-tools-
-      - name: PHPStan
-        uses: docker://phpdoc/phpstan-ga:latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup PHP
+        uses: shivammathur/setup-php@master
         with:
-          args: analyse src --level max --configuration phpstan.neon
+          php-version: 7.2
+          coverage: none
+      - name: Run PHPStan
+        run: php tools/psalm
 
   psalm:
     runs-on: ubuntu-latest
@@ -154,8 +154,7 @@ jobs:
         uses: shivammathur/setup-php@master
         with:
           php-version: 7.2
-          coverage: xdebug
-          pecl: false
+          coverage: none
       - name: Run psalm
         run: php tools/psalm
 
@@ -197,7 +196,6 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           extension-csv: mbstring, intl, iconv, libxml, dom, json, simplexml, zlib
           ini-values-csv: memory_limit=2G, display_errors=On, error_reporting=-1
-          pecl: false
       - name: Run PHPUnit
         continue-on-error: true
         run: php tools/phpunit

--- a/phive.xml
+++ b/phive.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpunit" version="^8.4.3" installed="8.5.15" location="./tools/phpunit" copy="true"/>
-  <phar name="phpstan" version="^0.12.1" installed="0.12.85" location="./tools/phpstan" copy="true"/>
-  <phar name="psalm" version="^3.7.2" installed="3.18.2" location="./tools/psalm" copy="true"/>
+  <phar name="phpunit" version="^8.4.3" installed="8.5.25" location="./tools/phpunit" copy="true"/>
+  <phar name="phpstan" version="^1.4.0" installed="1.4.10" location="./tools/phpstan" copy="true"/>
+  <phar name="psalm" version="^4.22.0" installed="4.22.0" location="./tools/psalm" copy="true"/>
   <phar name="composer-require-checker" version="^1.0.0" installed="1.1.0" location="./tools/composer-require-checker" copy="true"/>
 </phive>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+  level: max
+  paths:
+    - %currentWorkingDirectory%/src/
+  ignoreErrors:
+    - '/Offset .+ on array.+ in isset\(\) always exists and is not nullable./'

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="true"
+    errorLevel="1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     ensureArrayStringOffsetsExist="true"


### PR DESCRIPTION
Hi,

I got this error message while trying to install the tools with Phive:
```sh
# phive install
Phive 0.14.4 - Copyright (C) 2015-2022 by Arne Blankerts, Sebastian Heuer and Contributors
Downloading https://phar.phpunit.de/phpunit-8.5.15.phar
Downloading https://phar.phpunit.de/phpunit-8.5.15.phar.asc
Copying phpunit-8.5.15.phar to FlyFinder/tools/phpunit
[ERROR]    No matching release found!
```

The installation works after upgrading them, but I had to also update their configuration to make them pass.