### PR TITLE
Flysystem v3 port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ phpstan:
 
 .PHONY: psaml
 psalm:
-	docker run -it --rm -v${PWD}:/opt/project -w /opt/project php:7.4 tools/psalm
+	docker run -it --rm -v${PWD}:/opt/project -w /opt/project php:8.2 tools/psalm
 
 .PHONY: test
 test:
-	docker run -it --rm -v${PWD}:/opt/project -w /opt/project php:7.2 tools/phpunit
+	docker run -it --rm -v${PWD}:/opt/project -w /opt/project php:8.2 tools/phpunit
 
 .PHONY: pre-commit-test
 pre-commit-test: test phpcs phpstan psalm

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Flyfinder does *not* return directories themselves... only files.
 
 The easiest way to install this library is with [Composer](https://getcomposer.org) using the following command:
 
-    $ composer require rulatir/flyfinder
+    $ composer require phpdocumentor/flyfinder
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 FlyFinder
 =========
 
-FlyFinder is a plugin for [Flysystem](http://flysystem.thephpleague.com/) that will enable you to find files
+FlyFinder is a utility class for [Flysystem](http://flysystem.thephpleague.com/) that will enable you to find files
 based on certain criteria.
 
 FlyFinder can search for files that are hidden (either because they are hidden files themselves, or because they are
@@ -20,7 +20,7 @@ Flyfinder does *not* return directories themselves... only files.
 
 The easiest way to install this library is with [Composer](https://getcomposer.org) using the following command:
 
-    $ composer require phpdocumentor/flyfinder
+    $ composer require rulatir/flyfinder
 
 ## Examples
 
@@ -33,14 +33,14 @@ In order to use the FlyFinder plugin you first need a Flyfinder filesystem with 
 for instance the local adapter.
 
     use League\Flysystem\Filesystem;
-    use League\Flysystem\Adapter;
+    use League\Flysystem\Local\LocalFilesystemAdapter as LocalAdapter;
     use Flyfinder\Finder;
 
-    $filesystem = new Filesystem(new Adapter\Local(__DIR__.'/path/to/files/'));
+    $filesystem = new Filesystem(new LocalAdapter(__DIR__.'/path/to/files/'));
 
-Now you can add the plugin as follows:
+Now you can create the `Finder` instance:
 
-    $filesystem->addPlugin(new Finder());
+    $finder = new Finder($filesystem); 
 
 FlyFinder will need specifications to know what to look for. The following specifications are available:
 
@@ -74,6 +74,6 @@ extension.
 
 You can also make longer chains like this:
 
-` $specification = $inPath->andSpecification($hasExtension)->andSpecification($isHidden->notSpecification());`
+`$specification = $inPath->andSpecification($hasExtension)->andSpecification($isHidden->notSpecification());`
 
 This will find all files in the given path, that have the given extension and are not hidden.

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     }
   },
   "require": {
-    "php":              "^7.2||^8.0",
-    "league/flysystem": "^1.0"
+    "php":              "^8.0||^8.1||8.2",
+    "league/flysystem": "^3.0"
   },
   "minimum-stability":  "stable",
   "require-dev": {
     "mockery/mockery":  "^1.3",
-    "league/flysystem-memory": "~1"
+    "league/flysystem-memory": "~3"
   },
   "extra": {
     "branch-alias": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,58 +4,53 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0efac4e2b09809ebdee1c870f3ee817",
+    "content-hash": "58d7b7d024c0ad0685e661154f6792d1",
     "packages": [
         {
             "name": "league/flysystem",
-            "version": "1.1.10",
+            "version": "3.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "3239285c825c152bcc315fe0e87d6b55f5972ed1"
+                "reference": "2aef65a47e44f2d6f9938f720f6dd697e7ba7b76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/3239285c825c152bcc315fe0e87d6b55f5972ed1",
-                "reference": "3239285c825c152bcc315fe0e87d6b55f5972ed1",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/2aef65a47e44f2d6f9938f720f6dd697e7ba7b76",
+                "reference": "2aef65a47e44f2d6f9938f720f6dd697e7ba7b76",
                 "shasum": ""
             },
             "require": {
-                "ext-fileinfo": "*",
-                "league/mime-type-detection": "^1.3",
-                "php": "^7.2.5 || ^8.0"
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
             },
             "conflict": {
-                "league/flysystem-sftp": "<1.0.6"
+                "aws/aws-sdk-php": "3.209.31 || 3.210.0",
+                "guzzlehttp/guzzle": "<7.0",
+                "guzzlehttp/ringphp": "<1.1.1",
+                "phpseclib/phpseclib": "3.0.15",
+                "symfony/http-client": "<5.2"
             },
             "require-dev": {
-                "phpspec/prophecy": "^1.11.1",
-                "phpunit/phpunit": "^8.5.8"
-            },
-            "suggest": {
-                "ext-ftp": "Allows you to use FTP server storage",
-                "ext-openssl": "Allows you to use FTPS server storage",
-                "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
-                "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
-                "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
-                "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
-                "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
-                "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
-                "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
-                "league/flysystem-webdav": "Allows you to use WebDAV storage",
-                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter",
-                "spatie/flysystem-dropbox": "Allows you to use Dropbox storage",
-                "srmklive/flysystem-dropbox-v2": "Allows you to use Dropbox storage for PHP 5 applications"
+                "async-aws/s3": "^1.5",
+                "async-aws/simple-s3": "^1.1",
+                "aws/aws-sdk-php": "^3.198.1",
+                "composer/semver": "^3.0",
+                "ext-fileinfo": "*",
+                "ext-ftp": "*",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "^3.5",
+                "google/cloud-storage": "^1.23",
+                "microsoft/azure-storage-blob": "^1.1",
+                "phpseclib/phpseclib": "^3.0.14",
+                "phpstan/phpstan": "^0.12.26",
+                "phpunit/phpunit": "^9.5.11",
+                "sabre/dav": "^4.3.1"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
-                    "League\\Flysystem\\": "src/"
+                    "League\\Flysystem\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -65,40 +60,42 @@
             "authors": [
                 {
                     "name": "Frank de Jonge",
-                    "email": "info@frenky.net"
+                    "email": "info@frankdejonge.nl"
                 }
             ],
-            "description": "Filesystem abstraction: Many filesystems, one API.",
+            "description": "File storage abstraction for PHP",
             "keywords": [
-                "Cloud Files",
                 "WebDAV",
-                "abstraction",
                 "aws",
                 "cloud",
-                "copy.com",
-                "dropbox",
-                "file systems",
+                "file",
                 "files",
                 "filesystem",
                 "filesystems",
                 "ftp",
-                "rackspace",
-                "remote",
                 "s3",
                 "sftp",
                 "storage"
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/1.1.10"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.12.0"
             },
             "funding": [
                 {
-                    "url": "https://offset.earth/frankdejonge",
-                    "type": "other"
+                    "url": "https://ecologi.com/frankdejonge",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/frankdejonge",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/flysystem",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-10-04T09:16:37+00:00"
+            "time": "2022-12-20T20:21:10+00:00"
         },
         {
             "name": "league/mime-type-detection",
@@ -211,33 +208,27 @@
         },
         {
             "name": "league/flysystem-memory",
-            "version": "1.0.2",
+            "version": "3.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem-memory.git",
-                "reference": "d0e87477c32e29f999b4de05e64c1adcddb51757"
+                "reference": "5405162ac81f4de5aa5fa01aae7d07382b7c797b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem-memory/zipball/d0e87477c32e29f999b4de05e64c1adcddb51757",
-                "reference": "d0e87477c32e29f999b4de05e64c1adcddb51757",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-memory/zipball/5405162ac81f4de5aa5fa01aae7d07382b7c797b",
+                "reference": "5405162ac81f4de5aa5fa01aae7d07382b7c797b",
                 "shasum": ""
             },
             "require": {
-                "league/flysystem": "~1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7.10"
+                "ext-fileinfo": "*",
+                "league/flysystem": "^2.0.0 || ^3.0.0",
+                "php": "^8.0.2"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
-                    "League\\Flysystem\\Memory\\": "src/"
+                    "League\\Flysystem\\InMemory\\": ""
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -246,23 +237,37 @@
             ],
             "authors": [
                 {
-                    "name": "Chris Leppanen",
-                    "email": "chris.leppanen@gmail.com",
-                    "role": "Developer"
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
                 }
             ],
-            "description": "An in-memory adapter for Flysystem.",
-            "homepage": "https://github.com/thephpleague/flysystem-memory",
+            "description": "In-memory filesystem adapter for Flysystem.",
             "keywords": [
                 "Flysystem",
-                "adapter",
+                "file",
+                "files",
+                "filesystem",
                 "memory"
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem-memory/issues",
-                "source": "https://github.com/thephpleague/flysystem-memory/tree/1.0.2"
+                "source": "https://github.com/thephpleague/flysystem-memory/tree/3.10.3"
             },
-            "time": "2019-05-30T21:34:13+00:00"
+            "funding": [
+                {
+                    "url": "https://ecologi.com/frankdejonge",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/frankdejonge",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/flysystem",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-10-26T18:30:26+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -343,7 +348,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2||^8.0"
+        "php": "^7.2||^8.0||^8.1||8.2"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"

--- a/examples/01-find-hidden-files.php
+++ b/examples/01-find-hidden-files.php
@@ -2,7 +2,7 @@
 require_once(__DIR__ . '/../vendor/autoload.php');
 
 use League\Flysystem\Filesystem;
-use League\Flysystem\Memory\MemoryAdapter as Adapter;
+use League\Flysystem\InMemory\InMemoryFilesystemAdapter as Adapter;
 use Flyfinder\Finder;
 use Flyfinder\Specification\IsHidden;
 
@@ -11,7 +11,8 @@ use Flyfinder\Specification\IsHidden;
  * In this example we are using a filesystem with the memory adapter
  */
 $filesystem = new Filesystem(new Adapter());
-$filesystem->addPlugin(new Finder());
+$finder = new Finder();
+$finder->setFilesystem($filesystem);
 
 // Create some demo files
 $filesystem->write('test.txt', 'test');
@@ -22,7 +23,7 @@ $filesystem->write('.hiddendir/.test.txt', 'test');
 $specification = new IsHidden();
 
 //FlyFinder will yield a generator object with the files that are found
-$generator = $filesystem->find($specification);
+$generator = $finder->find($specification);
 
 $result = [];
 

--- a/examples/02-find-on-multiple-criteria.php
+++ b/examples/02-find-on-multiple-criteria.php
@@ -2,19 +2,20 @@
 require_once(__DIR__ . '/../vendor/autoload.php');
 
 use League\Flysystem\Filesystem;
-use League\Flysystem\Memory\MemoryAdapter as Adapter;
+use League\Flysystem\InMemory\InMemoryFilesystemAdapter as Adapter;
 use Flyfinder\Finder;
 use Flyfinder\Path;
 use Flyfinder\Specification\IsHidden;
 use Flyfinder\Specification\HasExtension;
-use Flyfinder\Specification\InPath;
+use Flyfinder\Specification\InPath;use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
 
 /*
  * First create a new Filesystem and add the FlySystem plugin
  * In this example we are using a filesystem with the memory adapter
  */
 $filesystem = new Filesystem(new Adapter());
-$filesystem->addPlugin(new Finder());
+$finder = new Finder();
+$finder->setFilesystem($filesystem);
 
 // Create some demo files
 $filesystem->write('test.txt', 'test');
@@ -33,7 +34,7 @@ $inPath = new InPath(new Path('.hiddendir'));
 $specification = $inPath->andSpecification($hasExtension)->andSpecification($isHidden->notSpecification());
 
 //FlyFinder will yield a generator object with the files that are found
-$generator = $filesystem->find($specification);
+$generator = $finder->find($specification);
 
 $result = [];
 

--- a/examples/03-sample-phpdoc-layout.php
+++ b/examples/03-sample-phpdoc-layout.php
@@ -2,7 +2,7 @@
 require_once(__DIR__ . '/../vendor/autoload.php');
 
 use League\Flysystem\Filesystem;
-use League\Flysystem\Adapter\Local;
+use League\Flysystem\Local\LocalFilesystemAdapter as Local;
 use Flyfinder\Finder;
 use Flyfinder\Path;
 use Flyfinder\Specification\IsHidden;
@@ -12,7 +12,8 @@ use Flyfinder\Specification\AndSpecification;
 
 // (03-sample-files based on some phpDocumentor2 src files)
 $filesystem = new Filesystem(new Local(__DIR__ . '/03-sample-files'));
-$filesystem->addPlugin(new Finder());
+$finder = new Finder();
+$finder->setFilesystem($filesystem);
 
 /*
  * "phpdoc -d src -i src/phpDocumentor/DomainModel"
@@ -27,7 +28,7 @@ $spec = new AndSpecification($dashDirectoryPath, $dashIgnorePath->notSpecificati
 $spec->andSpecification($isHidden->notSpecification());
 $spec->andSpecification($isPhpFile);
 
-$generator = $filesystem->find($spec);
+$generator = $finder->find($spec);
 $result = [];
 foreach($generator as $value) {
     $result[] = $value;

--- a/examples/04-sample-phpdoc-layout-using-glob.php
+++ b/examples/04-sample-phpdoc-layout-using-glob.php
@@ -3,7 +3,7 @@ require_once(__DIR__ . '/../vendor/autoload.php');
 
 use Flyfinder\Specification\Glob;
 use League\Flysystem\Filesystem;
-use League\Flysystem\Adapter\Local;
+use League\Flysystem\Local\LocalFilesystemAdapter as Local;
 use Flyfinder\Finder;
 use Flyfinder\Path;
 use Flyfinder\Specification\IsHidden;
@@ -13,7 +13,8 @@ use Flyfinder\Specification\AndSpecification;
 
 // (03-sample-files based on some phpDocumentor2 src files)
 $filesystem = new Filesystem(new Local(__DIR__ . '/03-sample-files'));
-$filesystem->addPlugin(new Finder());
+$finder = new Finder();
+$finder->setFilesystem($filesystem);
 
 /*
  * "phpdoc -d src -i src/phpDocumentor/DomainModel"
@@ -28,7 +29,7 @@ $spec = new AndSpecification($dashDirectoryPath, $dashIgnorePath->notSpecificati
 $spec->andSpecification($isHidden->notSpecification());
 $spec->andSpecification($isPhpFile);
 
-$generator = $filesystem->find($spec);
+$generator = $finder->find($spec);
 $result = [];
 foreach($generator as $value) {
     $result[] = $value;

--- a/src/Specification/AndSpecification.php
+++ b/src/Specification/AndSpecification.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Flyfinder\Specification;
 
+use League\Flysystem\StorageAttributes;
+
 /**
  * @psalm-immutable
  */
@@ -33,23 +35,18 @@ final class AndSpecification extends CompositeSpecification
         $this->other = $other;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function isSatisfiedBy(array $value): bool
+    public function isSatisfiedBy(array|StorageAttributes $value): bool
     {
         return $this->one->isSatisfiedBy($value) && $this->other->isSatisfiedBy($value);
     }
 
-    /** {@inheritDoc} */
-    public function canBeSatisfiedBySomethingBelow(array $value): bool
+    public function canBeSatisfiedBySomethingBelow(array|StorageAttributes $value): bool
     {
         return self::thatCanBeSatisfiedBySomethingBelow($this->one, $value)
             && self::thatCanBeSatisfiedBySomethingBelow($this->other, $value);
     }
 
-    /** {@inheritDoc} */
-    public function willBeSatisfiedByEverythingBelow(array $value): bool
+    public function willBeSatisfiedByEverythingBelow(array|StorageAttributes $value): bool
     {
         return self::thatWillBeSatisfiedByEverythingBelow($this->one, $value)
             && self::thatWillBeSatisfiedByEverythingBelow($this->other, $value);

--- a/src/Specification/CompositeSpecification.php
+++ b/src/Specification/CompositeSpecification.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Flyfinder\Specification;
 
+use League\Flysystem\StorageAttributes;
+
 /**
  * Base class for specifications, allows for combining specifications
  *
@@ -47,14 +49,12 @@ abstract class CompositeSpecification implements SpecificationInterface, Prunabl
         return new NotSpecification($this);
     }
 
-    /** {@inheritDoc} */
-    public function canBeSatisfiedBySomethingBelow(array $value): bool
+    public function canBeSatisfiedBySomethingBelow(array|StorageAttributes $value): bool
     {
         return true;
     }
 
-    /** {@inheritDoc} */
-    public function willBeSatisfiedByEverythingBelow(array $value): bool
+    public function willBeSatisfiedByEverythingBelow(array|StorageAttributes $value): bool
     {
         return false;
     }
@@ -63,12 +63,11 @@ abstract class CompositeSpecification implements SpecificationInterface, Prunabl
      * Provide default {@see canBeSatisfiedBySomethingBelow()} logic for specification classes
      * that don't implement PrunableInterface
      *
-     * @param mixed[] $value
-     * @psalm-param array{basename: string, path: string, stream: resource, dirname: string, type: string, extension: string} $value
+     * @psalm-param StorageAttributes|array{basename: string, path: string, stream: resource, dirname: string, type: string, extension: string} $value
      *
      * @psalm-mutation-free
      */
-    public static function thatCanBeSatisfiedBySomethingBelow(SpecificationInterface $that, array $value): bool
+    public static function thatCanBeSatisfiedBySomethingBelow(SpecificationInterface $that, array|StorageAttributes $value): bool
     {
         return $that instanceof PrunableInterface
                 ? $that->canBeSatisfiedBySomethingBelow($value)
@@ -79,12 +78,11 @@ abstract class CompositeSpecification implements SpecificationInterface, Prunabl
      * Provide default {@see willBeSatisfiedByEverythingBelow()} logic for specification classes
      * that don't implement PrunableInterface
      *
-     * @param mixed[] $value
-     * @psalm-param array{basename: string, path: string, stream: resource, dirname: string, type: string, extension: string} $value
+     * @psalm-param StorageAttributes|array{basename: string, path: string, stream: resource, dirname: string, type: string, extension: string} $value
      *
      * @psalm-mutation-free
      */
-    public static function thatWillBeSatisfiedByEverythingBelow(SpecificationInterface $that, array $value): bool
+    public static function thatWillBeSatisfiedByEverythingBelow(SpecificationInterface $that, array|StorageAttributes $value): bool
     {
         return $that instanceof PrunableInterface
             && $that->willBeSatisfiedByEverythingBelow($value);

--- a/src/Specification/HasExtension.php
+++ b/src/Specification/HasExtension.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace Flyfinder\Specification;
 
+use League\Flysystem\StorageAttributes;
+
 use function in_array;
+use function preg_match;
 
 /**
  * Files and directories meet the specification if they have the given extension
@@ -35,11 +38,18 @@ class HasExtension extends CompositeSpecification
         $this->extensions = $extensions;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function isSatisfiedBy(array $value): bool
+    public function isSatisfiedBy(array|StorageAttributes $value): bool
     {
-        return isset($value['extension']) && in_array($value['extension'], $this->extensions, false);
+        $matches = [];
+        /** @psalm-suppress ImpureMethodCall */
+        if (preg_match('/(^|\/)\.[^.]+$/', (string) $value['path'])) {
+            return false;
+        }
+
+        /** @psalm-suppress ImpureMethodCall */
+        preg_match('/\.([^.]+)$/', (string) $value['path'], $matches);
+        $extension = $matches[1] ?? null;
+
+        return $extension && in_array($extension, $this->extensions, false);
     }
 }

--- a/src/Specification/IsHidden.php
+++ b/src/Specification/IsHidden.php
@@ -13,7 +13,12 @@ declare(strict_types=1);
 
 namespace Flyfinder\Specification;
 
-use function substr;
+use League\Flysystem\StorageAttributes;
+
+use function pathinfo;
+use function str_starts_with;
+
+use const PATHINFO_BASENAME;
 
 /**
  * Files or directories meet the specification if they are hidden
@@ -22,11 +27,11 @@ use function substr;
  */
 class IsHidden extends CompositeSpecification
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function isSatisfiedBy(array $value): bool
+    public function isSatisfiedBy(array|StorageAttributes $value): bool
     {
-        return isset($value['basename']) && substr($value['basename'], 0, 1) === '.';
+        /** @psalm-suppress ImpureMethodCall */
+        $basename = pathinfo((string) $value['path'], PATHINFO_BASENAME);
+
+        return $basename && str_starts_with($basename, '.');
     }
 }

--- a/src/Specification/NotSpecification.php
+++ b/src/Specification/NotSpecification.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Flyfinder\Specification;
 
+use League\Flysystem\StorageAttributes;
+
 /**
  * @psalm-immutable
  */
@@ -29,22 +31,17 @@ final class NotSpecification extends CompositeSpecification
         $this->wrapped = $wrapped;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function isSatisfiedBy(array $value): bool
+    public function isSatisfiedBy(array|StorageAttributes $value): bool
     {
         return !$this->wrapped->isSatisfiedBy($value);
     }
 
-    /** @inheritDoc */
-    public function canBeSatisfiedBySomethingBelow(array $value): bool
+    public function canBeSatisfiedBySomethingBelow(array|StorageAttributes $value): bool
     {
         return !self::thatWillBeSatisfiedByEverythingBelow($this->wrapped, $value);
     }
 
-    /** @inheritDoc */
-    public function willBeSatisfiedByEverythingBelow(array $value): bool
+    public function willBeSatisfiedByEverythingBelow(array|StorageAttributes $value): bool
     {
         return !self::thatCanBeSatisfiedBySomethingBelow($this->wrapped, $value);
     }

--- a/src/Specification/OrSpecification.php
+++ b/src/Specification/OrSpecification.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Flyfinder\Specification;
 
+use League\Flysystem\StorageAttributes;
+
 /**
  * @psalm-immutable
  */
@@ -33,23 +35,18 @@ final class OrSpecification extends CompositeSpecification
         $this->other = $other;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function isSatisfiedBy(array $value): bool
+    public function isSatisfiedBy(array|StorageAttributes $value): bool
     {
         return $this->one->isSatisfiedBy($value) || $this->other->isSatisfiedBy($value);
     }
 
-    /** @inheritDoc */
-    public function canBeSatisfiedBySomethingBelow(array $value): bool
+    public function canBeSatisfiedBySomethingBelow(array|StorageAttributes $value): bool
     {
         return self::thatCanBeSatisfiedBySomethingBelow($this->one, $value)
             || self::thatCanBeSatisfiedBySomethingBelow($this->other, $value);
     }
 
-    /** @inheritDoc */
-    public function willBeSatisfiedByEverythingBelow(array $value): bool
+    public function willBeSatisfiedByEverythingBelow(array|StorageAttributes $value): bool
     {
         return self::thatWillBeSatisfiedByEverythingBelow($this->one, $value)
             || self::thatWillBeSatisfiedByEverythingBelow($this->other, $value);

--- a/src/Specification/PrunableInterface.php
+++ b/src/Specification/PrunableInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Flyfinder\Specification;
 
+use League\Flysystem\StorageAttributes;
+
 /**
  * @psalm-immutable
  */
@@ -12,17 +14,15 @@ interface PrunableInterface
     /**
      * Checks if anything under the directory path in value can possibly satisfy the specification.
      *
-     * @param mixed[] $value
-     * @psalm-param array{basename: string, path: string, stream: resource, dirname: string, type: string, extension: string} $value
+     * @psalm-param StorageAttributes|array{basename: string, path: string, stream: resource, dirname: string, type: string, extension: string} $value
      */
-    public function canBeSatisfiedBySomethingBelow(array $value): bool;
+    public function canBeSatisfiedBySomethingBelow(array|StorageAttributes $value): bool;
 
     /**
      * Returns true if it is known or can be deduced that everything under the directory path in value
      * will certainly satisfy the specification.
      *
-     * @param mixed[] $value
-     * @psalm-param array{basename: string, path: string, stream: resource, dirname: string, type: string, extension: string} $value
+     * @psalm-param StorageAttributes|array{basename: string, path: string, stream: resource, dirname: string, type: string, extension: string} $value
      */
-    public function willBeSatisfiedByEverythingBelow(array $value): bool;
+    public function willBeSatisfiedByEverythingBelow(array|StorageAttributes $value): bool;
 }

--- a/src/Specification/SpecificationInterface.php
+++ b/src/Specification/SpecificationInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Flyfinder\Specification;
 
+use League\Flysystem\StorageAttributes;
+
 /**
  * Interface for FlyFinder specifications
  *
@@ -23,8 +25,7 @@ interface SpecificationInterface
     /**
      * Checks if the value meets the specification
      *
-     * @param mixed[] $value
-     * @psalm-param array{basename: string, path: string, stream: resource, dirname: string, type: string, extension: string} $value
+     * @psalm-param StorageAttributes|array{basename: string, path: string, stream: resource, dirname: string, type: string, extension: string} $value
      */
-    public function isSatisfiedBy(array $value): bool;
+    public function isSatisfiedBy(array|StorageAttributes $value): bool;
 }

--- a/tests/integration/FindHiddenFilesTest.php
+++ b/tests/integration/FindHiddenFilesTest.php
@@ -15,6 +15,10 @@ namespace Flyfinder;
 
 use PHPUnit\Framework\TestCase;
 
+use function pathinfo;
+
+use const PATHINFO_BASENAME;
+
 /**
  * Integration test against examples/01-find-hidden-files.php
  *
@@ -28,6 +32,6 @@ class FindHiddenFilesTest extends TestCase
         include __DIR__ . '/../../examples/01-find-hidden-files.php';
 
         $this->assertCount(1, $result);
-        $this->assertSame('.test.txt', $result[0]['basename']);
+        $this->assertSame('.test.txt', pathinfo($result[0]['path'], PATHINFO_BASENAME));
     }
 }

--- a/tests/integration/FindOnMultipleCriteriaTest.php
+++ b/tests/integration/FindOnMultipleCriteriaTest.php
@@ -15,6 +15,10 @@ namespace Flyfinder;
 
 use PHPUnit\Framework\TestCase;
 
+use function pathinfo;
+
+use const PATHINFO_BASENAME;
+
 /**
  * Integration test against examples/02-find-on-multiple-criteria.php
  *
@@ -26,9 +30,10 @@ class FindOnMultipleCriteriaTest extends TestCase
     {
         $result = [];
         include __DIR__ . '/../../examples/02-find-on-multiple-criteria.php';
+        $basenameOf = static fn ($value) => pathinfo($value['path'], PATHINFO_BASENAME);
 
         $this->assertCount(2, $result);
-        $this->assertSame('found.txt', $result[0]['basename']);
-        $this->assertSame('example.txt', $result[1]['basename']);
+        $this->assertSame('found.txt', $basenameOf($result[0]));
+        $this->assertSame('example.txt', $basenameOf($result[1]));
     }
 }

--- a/tests/integration/FindOnSamplePhpdocLayoutTest.php
+++ b/tests/integration/FindOnSamplePhpdocLayoutTest.php
@@ -15,6 +15,10 @@ namespace Flyfinder;
 
 use PHPUnit\Framework\TestCase;
 
+use function pathinfo;
+
+use const PATHINFO_BASENAME;
+
 /**
  * Integration test against examples/03-sample-phpdoc-layout.php
  *
@@ -26,11 +30,12 @@ class FindOnSamplePhpdocLayoutTest extends TestCase
     {
         $result = [];
         include __DIR__ . '/../../examples/03-sample-phpdoc-layout.php';
+        $basenameOf = static fn ($value) => pathinfo($value['path'], PATHINFO_BASENAME);
 
         $this->assertCount(4, $result);
-        $this->assertSame('JmsSerializerServiceProvider.php', $result[0]['basename']);
-        $this->assertSame('MonologServiceProvider.php', $result[1]['basename']);
-        $this->assertSame('Application.php', $result[2]['basename']);
-        $this->assertSame('Bootstrap.php', $result[3]['basename']);
+        $this->assertSame('JmsSerializerServiceProvider.php', $basenameOf($result[0]));
+        $this->assertSame('MonologServiceProvider.php', $basenameOf($result[1]));
+        $this->assertSame('Application.php', $basenameOf($result[2]));
+        $this->assertSame('Bootstrap.php', $basenameOf($result[3]));
     }
 }

--- a/tests/integration/FindOnSamplePhpdocLayoutUsingGlobTest.php
+++ b/tests/integration/FindOnSamplePhpdocLayoutUsingGlobTest.php
@@ -15,6 +15,10 @@ namespace Flyfinder;
 
 use PHPUnit\Framework\TestCase;
 
+use function pathinfo;
+
+use const PATHINFO_BASENAME;
+
 /**
  * Integration test against examples/04-sample-phpdoc-layout-using-glob.php
  *
@@ -26,11 +30,12 @@ class FindOnSamplePhpdocLayoutUsingGlobTest extends TestCase
     {
         $result = [];
         include __DIR__ . '/../../examples/04-sample-phpdoc-layout-using-glob.php';
+        $basenameOf = static fn ($value) => pathinfo($value['path'], PATHINFO_BASENAME);
 
         $this->assertCount(4, $result);
-        $this->assertSame('JmsSerializerServiceProvider.php', $result[0]['basename']);
-        $this->assertSame('MonologServiceProvider.php', $result[1]['basename']);
-        $this->assertSame('Application.php', $result[2]['basename']);
-        $this->assertSame('Bootstrap.php', $result[3]['basename']);
+        $this->assertSame('JmsSerializerServiceProvider.php', $basenameOf($result[0]));
+        $this->assertSame('MonologServiceProvider.php', $basenameOf($result[1]));
+        $this->assertSame('Application.php', $basenameOf($result[2]));
+        $this->assertSame('Bootstrap.php', $basenameOf($result[3]));
     }
 }

--- a/tests/unit/Specification/HasExtensionTest.php
+++ b/tests/unit/Specification/HasExtensionTest.php
@@ -45,7 +45,7 @@ class HasExtensionTest extends TestCase
      */
     public function testIfSpecificationIsSatisfied(): void
     {
-        $this->assertTrue($this->fixture->isSatisfiedBy(['extension' => 'txt']));
+        $this->assertTrue($this->fixture->isSatisfiedBy(['path' => 'foo.txt']));
     }
 
     /**
@@ -54,6 +54,6 @@ class HasExtensionTest extends TestCase
      */
     public function testIfSpecificationIsNotSatisfied(): void
     {
-        $this->assertFalse($this->fixture->isSatisfiedBy(['extension' => 'php']));
+        $this->assertFalse($this->fixture->isSatisfiedBy(['path' => 'foo.php']));
     }
 }

--- a/tests/unit/Specification/InPathTest.php
+++ b/tests/unit/Specification/InPathTest.php
@@ -71,7 +71,7 @@ class InPathTest extends TestCase
     public function testIfSpecificationIsSatisfied(string $dirname): void
     {
         $this->useWildcardPath();
-        $this->assertTrue($this->fixture->isSatisfiedBy(['dirname' => $dirname]));
+        $this->assertTrue($this->fixture->isSatisfiedBy(['path' => $dirname]));
     }
 
     /**
@@ -84,7 +84,7 @@ class InPathTest extends TestCase
     public function testWithSingleDotSpec(string $dirname): void
     {
         $spec = new InPath(new Path('.'));
-        $this->assertTrue($spec->isSatisfiedBy(['dirname' => $dirname]));
+        $this->assertTrue($spec->isSatisfiedBy(['path' => $dirname]));
     }
 
     /**
@@ -97,7 +97,7 @@ class InPathTest extends TestCase
     public function testWithCurrentDirSpec(string $dirname): void
     {
         $spec = new InPath(new Path('./'));
-        $this->assertTrue($spec->isSatisfiedBy(['dirname' => $dirname]));
+        $this->assertTrue($spec->isSatisfiedBy(['path' => $dirname]));
     }
 
     /**
@@ -126,7 +126,7 @@ class InPathTest extends TestCase
     public function testIfSpecificationIsNotSatisfied(string $dirname): void
     {
         $this->useWildcardPath();
-        $this->assertFalse($this->fixture->isSatisfiedBy(['dirname' => $dirname]));
+        $this->assertFalse($this->fixture->isSatisfiedBy(['path' => $dirname]));
     }
 
     /**

--- a/tests/unit/Specification/IsHiddenTest.php
+++ b/tests/unit/Specification/IsHiddenTest.php
@@ -44,7 +44,7 @@ class IsHiddenTest extends TestCase
      */
     public function testIfSpecificationIsSatisfied(): void
     {
-        $this->assertTrue($this->fixture->isSatisfiedBy(['basename' => '.test']));
+        $this->assertTrue($this->fixture->isSatisfiedBy(['path' => '.test']));
     }
 
     /**
@@ -52,6 +52,6 @@ class IsHiddenTest extends TestCase
      */
     public function testIfSpecificationIsNotSatisfied(): void
     {
-        $this->assertFalse($this->fixture->isSatisfiedBy(['basename' => 'test']));
+        $this->assertFalse($this->fixture->isSatisfiedBy(['path' => 'test']));
     }
 }


### PR DESCRIPTION
This is a preliminary PR porting FlyFinder to Flysystem 3 and minimum PHP 8, motivated by our use of (and contributions to) FlyFinder, combined with our desire to free ourselves from the antedeluvial Flysystem 1 dependence.

Summary:

 - Flysystem 3 got rid of plugins, so control is now inverted: `Finder` constructor takes a `FilesystemOperator` object, `handle()` was renamed to `find()`, and you invoke it on the `Finder` object.
 - Methods that used to take an `array` with file/directory attributes will take `array|StorageAttributes` now. This is preliminary, and the `array` alternative is probably only used in tests that will need further tweaking to properly mock `FileAttributes` and `DirectoryAttributes` objects.
 - Implementation had to be tweaked to parse the path in various ways as necessary (with `pathinfo()`, regex, `str_*()`), because `StorageAttributes` only offer unparsed `path` - this is an optimization decision by Flysystem authors, to avoid parsing every path where it isn't known to be needed.
 
Things I got green:

 - tests (modulo `StorageAttributes` mocking)
 - phpcs
 - psalm (mostly)

Things I'd appreciate help with:

 - phpstan - the command in the Makefile uses an image that can't be easily bumped to PHP 8 by changing a tag.
 - Deciding what to do with `@psalm-pure`. Previously native array accesses to `$value['path']` are now `ProxyArrayAccessToProperties::offsetGet()`, and Flysystem authors either neglected or couldn't mark it as pure. We can give up being pure ourselves, suppress the diagnostic (which is what I did for now), or plead with Flysystem authors.
 - No idea what phive is, `make install-phive` fails on `gpg --recv-keys`
 - How to properly tag and alias v1 and v3 in composer.json
 - Anything I missed